### PR TITLE
[WIP] Change architecture with StateNotifier

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,6 +55,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: transitive
+    description:
+      name: flutter_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.0"
   flutter_lints:
     dependency: transitive
     description:
@@ -62,11 +69,39 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.2"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.7"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   lints:
     dependency: transitive
     description:
@@ -102,6 +137,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.13.0+3"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -128,6 +170,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  state_notifier:
+    dependency: "direct main"
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   stream_channel:
     dependency: transitive
     description:
@@ -179,3 +228,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.13.0 <3.0.0"
+  flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  hooks_riverpod: ^1.0.0-dev.7
+  state_notifier:
   swipeable_stack:
     path:
       ../

--- a/lib/src/swipeable_stack.dart
+++ b/lib/src/swipeable_stack.dart
@@ -259,7 +259,10 @@ extension _AnimationControllerX on AnimationController {
     ).animate(
       CurvedAnimation(
         parent: this,
-        curve: Sprung.criticallyDamped,
+        curve: Sprung.custom(
+          stiffness: 180,
+          mass: 1.0,
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -128,6 +128,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  state_notifier:
+    dependency: "direct main"
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   sprung: ^3.0.0
+  state_notifier:
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
# Overview
`ChangeNotifier` に依存していることで、丁寧にパフォーマンスを考慮しているアプリで使いづらい。

# Path
- [ ] CardProperties の情報を _State 側に移す
- [ ] State 用のクラスを作成する
- [ ] ChangeNotifier を StateNotifier に置き換える
 
